### PR TITLE
Add basic utilities and extend legal agents

### DIFF
--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -1,0 +1,40 @@
+# Setup Guide
+
+This project provides a simple LangGraph implementation of an AI lawyer agent. The backend is built with FastAPI and the frontend uses Next.js.
+
+## Prerequisites
+
+- Python 3.10+
+- Node.js (for the `ui` package)
+
+## Installation
+
+1. Create a virtual environment and install the Python dependencies:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+2. Copy `.env.example` to `.env` and fill in your API keys:
+
+```bash
+cp .env.example .env
+```
+
+3. Run the FastAPI server:
+
+```bash
+uvicorn src.api.main:app --reload
+```
+
+4. (Optional) Install frontend dependencies and start the Next.js dev server:
+
+```bash
+cd ui
+npm install
+npm run dev
+```
+
+The API will be available at `http://localhost:8000` and the frontend at `http://localhost:3000` by default.

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,12 @@ PyPDF2==3.0.1
 PyPika==0.48.9
 pyproject_hooks==1.2.0
 python-dotenv==1.1.1
+fastapi==0.110.0
+uvicorn==0.29.0
+langgraph==0.0.39
+langchain-core==0.1.35
+langchain-openai==0.1.7
+openai==1.30.1
 python-multipart==0.0.20
 pytz==2025.2
 PyYAML==6.0.2

--- a/src/agents/legal_agents.py
+++ b/src/agents/legal_agents.py
@@ -111,41 +111,139 @@ class CriminalLawAgent(BaseLegalAgent):
 class CivilLawAgent(BaseLegalAgent):
     def __init__(self, llm):
         super().__init__(llm, "civil")
-    
+
     def process_query(self, state: Dict[str, Any]) -> Dict[str, Any]:
-        return {"advice": "Civil law analysis", "citations": [], "confidence": 0.8}
+        messages = state["messages"]
+        latest_query = messages[-1].content if messages else ""
+
+        prompt = ChatPromptTemplate.from_messages([
+            (
+                "system",
+                """You are an expert in Indian Civil Law. Provide key statutes and case law relevant to the query.""",
+            ),
+            ("human", "{query}"),
+        ])
+        response = self.llm.invoke(prompt.format_messages(query=latest_query))
+
+        return {
+            "advice": response.content,
+            "citations": [],
+            "confidence": 0.8,
+        }
 
 class CorporateLawAgent(BaseLegalAgent):
     def __init__(self, llm):
         super().__init__(llm, "corporate")
-    
+
     def process_query(self, state: Dict[str, Any]) -> Dict[str, Any]:
-        return {"advice": "Corporate law analysis", "citations": [], "confidence": 0.8}
+        messages = state["messages"]
+        latest_query = messages[-1].content if messages else ""
+
+        prompt = ChatPromptTemplate.from_messages([
+            (
+                "system",
+                """You are an expert in Indian Corporate Law. Discuss relevant sections of the Companies Act and notable judgments.""",
+            ),
+            ("human", "{query}"),
+        ])
+
+        response = self.llm.invoke(prompt.format_messages(query=latest_query))
+
+        return {
+            "advice": response.content,
+            "citations": [],
+            "confidence": 0.8,
+        }
 
 class FamilyLawAgent(BaseLegalAgent):
     def __init__(self, llm):
         super().__init__(llm, "family")
-    
+
     def process_query(self, state: Dict[str, Any]) -> Dict[str, Any]:
-        return {"advice": "Family law analysis", "citations": [], "confidence": 0.8}
+        messages = state["messages"]
+        latest_query = messages[-1].content if messages else ""
+
+        prompt = ChatPromptTemplate.from_messages([
+            (
+                "system",
+                """You are an expert in Indian Family Law. Explain how personal laws apply to the query.""",
+            ),
+            ("human", "{query}"),
+        ])
+
+        response = self.llm.invoke(prompt.format_messages(query=latest_query))
+
+        return {
+            "advice": response.content,
+            "citations": [],
+            "confidence": 0.8,
+        }
 
 class TaxLawAgent(BaseLegalAgent):
     def __init__(self, llm):
         super().__init__(llm, "tax")
-    
+
     def process_query(self, state: Dict[str, Any]) -> Dict[str, Any]:
-        return {"advice": "Tax law analysis", "citations": [], "confidence": 0.8}
+        messages = state["messages"]
+        latest_query = messages[-1].content if messages else ""
+
+        prompt = ChatPromptTemplate.from_messages([
+            (
+                "system",
+                """You are an expert in Indian Taxation Law. Provide guidance using relevant sections of the Income Tax Act.""",
+            ),
+            ("human", "{query}"),
+        ])
+        response = self.llm.invoke(prompt.format_messages(query=latest_query))
+
+        return {
+            "advice": response.content,
+            "citations": [],
+            "confidence": 0.8,
+        }
 
 class LegalResearchAgent(BaseLegalAgent):
     def __init__(self, llm):
         super().__init__(llm, "research")
-    
+
     def process_query(self, state: Dict[str, Any]) -> Dict[str, Any]:
-        return {"advice": "Legal research analysis", "citations": [], "confidence": 0.8}
+        messages = state["messages"]
+        latest_query = messages[-1].content if messages else ""
+
+        prompt = ChatPromptTemplate.from_messages([
+            (
+                "system",
+                """You perform legal research across Indian case law and statutes. Provide concise findings.""",
+            ),
+            ("human", "{query}"),
+        ])
+        response = self.llm.invoke(prompt.format_messages(query=latest_query))
+
+        return {
+            "advice": response.content,
+            "citations": [],
+            "confidence": 0.8,
+        }
 
 class DocumentAnalysisAgent(BaseLegalAgent):
     def __init__(self, llm):
         super().__init__(llm, "document_analysis")
-    
+
     def process_query(self, state: Dict[str, Any]) -> Dict[str, Any]:
-        return {"advice": "Document analysis", "citations": [], "confidence": 0.8}
+        messages = state["messages"]
+        latest_query = messages[-1].content if messages else ""
+
+        prompt = ChatPromptTemplate.from_messages([
+            (
+                "system",
+                """You analyze uploaded legal documents. Summarize key points relevant to the query.""",
+            ),
+            ("human", "{query}"),
+        ])
+        response = self.llm.invoke(prompt.format_messages(query=latest_query))
+
+        return {
+            "advice": response.content,
+            "citations": [],
+            "confidence": 0.8,
+        }

--- a/src/agents/legal_graph.py
+++ b/src/agents/legal_graph.py
@@ -74,6 +74,10 @@ class LegalAgentGraph:
         graph.add_node("router", self._route_query)
         graph.add_node("constitutional_agent", self._constitutional_handler)
         graph.add_node("criminal_agent", self._criminal_handler)
+        graph.add_node("civil_agent", self._civil_handler)
+        graph.add_node("corporate_agent", self._corporate_handler)
+        graph.add_node("family_agent", self._family_handler)
+        graph.add_node("tax_agent", self._tax_handler)
         graph.add_node("synthesizer", self._synthesize_response)
         
         # Add edges
@@ -86,13 +90,21 @@ class LegalAgentGraph:
             {
                 "constitutional": "constitutional_agent",
                 "criminal": "criminal_agent",
-                "synthesizer": "synthesizer"
+                "civil": "civil_agent",
+                "corporate": "corporate_agent",
+                "family": "family_agent",
+                "tax": "tax_agent",
+                "synthesizer": "synthesizer",
             }
         )
-        
+
         # All agents go to synthesizer
         graph.add_edge("constitutional_agent", "synthesizer")
         graph.add_edge("criminal_agent", "synthesizer")
+        graph.add_edge("civil_agent", "synthesizer")
+        graph.add_edge("corporate_agent", "synthesizer")
+        graph.add_edge("family_agent", "synthesizer")
+        graph.add_edge("tax_agent", "synthesizer")
         graph.add_edge("synthesizer", END)
         
         return graph.compile()
@@ -104,11 +116,19 @@ class LegalAgentGraph:
         
         # Simple keyword-based routing (can be enhanced with ML classification)
         domain = "general"
-        
+
         if any(word in latest_message.lower() for word in ["constitution", "fundamental rights", "article"]):
             domain = "constitutional"
         elif any(word in latest_message.lower() for word in ["crime", "criminal", "ipc", "murder", "theft"]):
             domain = "criminal"
+        elif any(word in latest_message.lower() for word in ["contract", "property", "tort", "civil"]):
+            domain = "civil"
+        elif any(word in latest_message.lower() for word in ["company", "shareholder", "corporate"]):
+            domain = "corporate"
+        elif any(word in latest_message.lower() for word in ["marriage", "divorce", "custody"]):
+            domain = "family"
+        elif any(word in latest_message.lower() for word in ["tax", "income tax", "gst"]):
+            domain = "tax"
         
         state["legal_domain"] = domain
         state["current_agent"] = domain
@@ -119,10 +139,16 @@ class LegalAgentGraph:
         """Decide which agent to route to"""
         domain = state.get("legal_domain", "general")
         
-        if domain in ["constitutional", "criminal"]:
+        if domain in [
+            "constitutional",
+            "criminal",
+            "civil",
+            "corporate",
+            "family",
+            "tax",
+        ]:
             return domain
-        else:
-            return "synthesizer"
+        return "synthesizer"
     
     def _constitutional_handler(self, state: LegalAgentState) -> LegalAgentState:
         """Handle constitutional law queries"""
@@ -151,7 +177,60 @@ class LegalAgentGraph:
         # Add AI response to messages
         ai_message = AIMessage(content=result["advice"])
         state["messages"].append(ai_message)
-        
+
+        return state
+
+    def _civil_handler(self, state: LegalAgentState) -> LegalAgentState:
+        """Handle civil law queries"""
+        agent = self.agents["civil"]
+        result = agent.process_query(state)
+
+        state["legal_advice"] = result["advice"]
+        state["confidence_score"] = result["confidence"]
+        state["citations"] = result["citations"]
+
+        ai_message = AIMessage(content=result["advice"])
+        state["messages"].append(ai_message)
+
+        return state
+
+    def _corporate_handler(self, state: LegalAgentState) -> LegalAgentState:
+        agent = self.agents["corporate"]
+        result = agent.process_query(state)
+
+        state["legal_advice"] = result["advice"]
+        state["confidence_score"] = result["confidence"]
+        state["citations"] = result["citations"]
+
+        ai_message = AIMessage(content=result["advice"])
+        state["messages"].append(ai_message)
+
+        return state
+
+    def _family_handler(self, state: LegalAgentState) -> LegalAgentState:
+        agent = self.agents["family"]
+        result = agent.process_query(state)
+
+        state["legal_advice"] = result["advice"]
+        state["confidence_score"] = result["confidence"]
+        state["citations"] = result["citations"]
+
+        ai_message = AIMessage(content=result["advice"])
+        state["messages"].append(ai_message)
+
+        return state
+
+    def _tax_handler(self, state: LegalAgentState) -> LegalAgentState:
+        agent = self.agents["tax"]
+        result = agent.process_query(state)
+
+        state["legal_advice"] = result["advice"]
+        state["confidence_score"] = result["confidence"]
+        state["citations"] = result["citations"]
+
+        ai_message = AIMessage(content=result["advice"])
+        state["messages"].append(ai_message)
+
         return state
     
     def _synthesize_response(self, state: LegalAgentState) -> LegalAgentState:

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -1,2 +1,13 @@
+"""Utility modules for AI Lawyer Agent."""
 
-# Utility modules for document processing and legal knowledge
+from .legal_knowledge import LegalKnowledgeBase
+from .context_manager import count_tokens, trim_messages, format_legal_response
+from .document_processor import DocumentProcessor
+
+__all__ = [
+    "LegalKnowledgeBase",
+    "count_tokens",
+    "trim_messages",
+    "format_legal_response",
+    "DocumentProcessor",
+]

--- a/src/utils/context_manager.py
+++ b/src/utils/context_manager.py
@@ -1,0 +1,26 @@
+"""Utility functions for managing conversation context."""
+from typing import List, Any
+
+
+def count_tokens(messages: List[Any]) -> int:
+    """Naive token count based on whitespace splitting."""
+    return sum(len(getattr(m, "content", "").split()) for m in messages)
+
+
+def trim_messages(messages: List[Any], max_tokens: int) -> List[Any]:
+    """Trim messages so that total tokens do not exceed max_tokens."""
+    trimmed: List[Any] = []
+    total = 0
+    for msg in reversed(messages):
+        tokens = len(getattr(msg, "content", "").split())
+        if total + tokens > max_tokens:
+            break
+        trimmed.append(msg)
+        total += tokens
+    return list(reversed(trimmed))
+
+
+def format_legal_response(text: str, citations: List[str], confidence: float) -> str:
+    """Format the response for API consumers."""
+    citation_text = "; ".join(citations) if citations else "No citations"
+    return f"{text}\n\nCitations: {citation_text}\nConfidence: {confidence:.2f}"

--- a/src/utils/document_processor.py
+++ b/src/utils/document_processor.py
@@ -1,0 +1,35 @@
+"""Simple document processing utilities."""
+import os
+from typing import Optional
+
+
+class DocumentProcessor:
+    """Processes uploaded documents into text."""
+
+    def __init__(self, upload_dir: Optional[str] = None) -> None:
+        self.upload_dir = upload_dir or os.path.join(os.getcwd(), "uploads")
+        os.makedirs(self.upload_dir, exist_ok=True)
+
+    def save_file(self, filename: str, data: bytes) -> str:
+        path = os.path.join(self.upload_dir, filename)
+        with open(path, "wb") as f:
+            f.write(data)
+        return path
+
+    def parse_pdf(self, path: str) -> str:
+        text = ""
+        try:
+            from PyPDF2 import PdfReader  # type: ignore
+        except Exception:  # pragma: no cover - optional dependency
+            raise RuntimeError("PyPDF2 is required for PDF parsing")
+
+        reader = PdfReader(path)
+        for page in reader.pages:
+            text += page.extract_text() or ""
+        return text
+
+    def load(self, path: str) -> str:
+        if path.lower().endswith(".pdf"):
+            return self.parse_pdf(path)
+        with open(path, "r", encoding="utf-8") as f:
+            return f.read()

--- a/src/utils/legal_knowledge.py
+++ b/src/utils/legal_knowledge.py
@@ -1,0 +1,25 @@
+"""Simple knowledge base for legal references."""
+from typing import Optional
+
+class LegalKnowledgeBase:
+    """A very small in-memory knowledge base for demo purposes."""
+
+    def __init__(self) -> None:
+        # Example constitutional articles and IPC sections
+        self.articles = {
+            "article 19": "Protection of certain rights regarding freedom of speech and expression",
+            "article 21": "Protection of life and personal liberty",
+        }
+        self.sections = {
+            "ipc 420": "Cheating and dishonestly inducing delivery of property",
+            "ipc 376": "Punishment for rape",
+        }
+
+    def search(self, term: str) -> Optional[str]:
+        """Return a short description for a matching article or section."""
+        key = term.lower()
+        if key in self.articles:
+            return f"{term.upper()}: {self.articles[key]}"
+        if key in self.sections:
+            return f"{term.upper()}: {self.sections[key]}"
+        return None

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+from dataclasses import dataclass
+import sys
+import os
+
+sys.path.insert(0, os.path.abspath(os.path.join(Path(__file__).resolve().parents[1], "")))
+
+from src.utils import count_tokens, trim_messages, DocumentProcessor, LegalKnowledgeBase
+
+
+@dataclass
+class Message:
+    content: str
+
+def test_count_tokens():
+    messages = [Message(content="hello world"), Message(content="test message")]
+    assert count_tokens(messages) == 4
+
+def test_trim_messages():
+    messages = [Message(content="a " * 50), Message(content="b " * 50)]
+    trimmed = trim_messages(messages, max_tokens=60)
+    assert len(trimmed) == 1
+
+
+def test_document_processor(tmp_path: Path):
+    file_path = tmp_path / "sample.txt"
+    file_path.write_text("sample text")
+    processor = DocumentProcessor(str(tmp_path))
+    loaded = processor.load(str(file_path))
+    assert "sample text" in loaded
+
+
+def test_legal_knowledge_search():
+    kb = LegalKnowledgeBase()
+    assert kb.search("article 19") is not None
+


### PR DESCRIPTION
## Summary
- implement missing util modules (`legal_knowledge`, `context_manager`, `document_processor`)
- expose utilities via `src.utils`
- flesh out civil, corporate, family, tax, research, and document agents
- expand `LegalAgentGraph` to route to new agents
- add requirements for FastAPI, LangGraph, and OpenAI
- provide basic setup instructions
- add simple unit tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d370a740c832592572694d5fc3ae3